### PR TITLE
Override DefaultSpecFactory reference date

### DIFF
--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -16,3 +16,4 @@ parameters:
     - src/Spec/VocaLinkV380/DataV480.php
     - src/Spec/VocaLinkV380/DataV490.php
     - src/Spec/VocaLinkV380/DataV500.php
+    - src/Spec/VocaLinkV380/DataV510.php

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Implemented VocaLink V5.10 specification.
+- New `DefaultSpecFactory::withDate()` method to overload the date reference
+  point for selection specifications.
+
+### Deprecated
+- Marked `DefaultSpecFactory::withNow()` for removal, was `@internal` so should
+  not impact consumers of this library. Use instance method
+  `DefaultSpecFactory::withDate()` instead.
 
 ## [v1.7.0] - 2018-07-04
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,17 @@ normalisation results.
   sort code and account number could not be validated the value of the `$assume`
   argument is returned.
 
+### Specification Factory
+
+The default specification factory (`Spec\DefaultSpecFactory`) picks the most
+appropriate specification for the current time.
+
+If you need to test the validity of a sort code and account number at a particular
+point in time, you can use the `withDate(\DateTimeInterface|string $date): self`
+method to overload the currently used time reference. If you supply an object to
+this method it will convert it to the date in `Europe/London`, string date is
+used verbatim.
+
 ### Exceptions
 
 This library will throw exceptions implementing `Exception\Exception` if

--- a/src/Exception/Util.php
+++ b/src/Exception/Util.php
@@ -32,6 +32,10 @@ final class Util
 
     public static function wrap(\InvalidArgumentException $e)
     {
+        if ($e instanceof InvalidArgumentException) {
+            return $e;
+        }
+
         return new InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
     }
 }

--- a/src/Spec/DefaultSpecFactory.php
+++ b/src/Spec/DefaultSpecFactory.php
@@ -56,21 +56,7 @@ final class DefaultSpecFactory implements SpecFactoryInterface
                 ));
             }
         } else {
-            // @todo Remove this compatability check, didn't want to force upgrade of assert library.
-            if (method_exists('Webmozart\\Assert\\Assert', 'isInstanceOfAny')) {
-                try {
-                    Assert::isInstanceOfAny($date, [
-                        'DateTimeInterface',
-                        'DateTime',
-                        'DateTimeImmutable',
-                    ]);
-                } catch (\InvalidArgumentException $e) {
-                    throw E::wrap($e);
-                }
-            // Only need to check two here as \DateTimeImmutable is an instance of DateTimeInterface.
-            } elseif (!$date instanceof \DateTime && !$date instanceof \DateTimeInterface) {
-                throw new InvalidArgumentException('Expected an instance of any of "DateTimeInterface", "DateTime", "DateTimeImmutable".');
-            }
+            self::assertDateTimeObject($date);
 
             // Internally this library has to support PHP 5.4 so ensure using DateTime
             // this also has the benefit of removing any time component which is not
@@ -172,5 +158,29 @@ final class DefaultSpecFactory implements SpecFactoryInterface
         assert($when instanceof \DateTime);
 
         return $this->now >= $when;
+    }
+
+    /**
+     * @codeCoverageIgnore
+     *
+     * @todo Remove when PHP < 5.5 is not supported
+     *
+     * @internal
+     *
+     * @param mixed $input
+     */
+    private static function assertDateTimeObject($input)
+    {
+        try {
+            if (interface_exists('DateTimeInterface')) {
+                Assert::isInstanceOf($input, 'DateTimeInterface');
+
+                return;
+            }
+
+            Assert::isInstanceOf($input, 'DateTime');
+        } catch (\InvalidArgumentException $e) {
+            throw E::wrap($e);
+        }
     }
 }

--- a/src/Spec/DefaultSpecFactory.php
+++ b/src/Spec/DefaultSpecFactory.php
@@ -66,6 +66,8 @@ final class DefaultSpecFactory implements SpecFactoryInterface
             $now->setTimezone($this->tz);
         }
 
+        assert($now instanceof \DateTime);
+
         $factory = new self();
         $factory->now = $now;
         $factory->updateNow = false;

--- a/src/Spec/DefaultSpecFactory.php
+++ b/src/Spec/DefaultSpecFactory.php
@@ -2,6 +2,10 @@
 
 namespace Cs278\BankModulus\Spec;
 
+use Cs278\BankModulus\Exception\InvalidArgumentException;
+use Cs278\BankModulus\Exception\Util as E;
+use Webmozart\Assert\Assert;
+
 /**
  * Default factory implementation.
  *
@@ -26,7 +30,67 @@ final class DefaultSpecFactory implements SpecFactoryInterface
     }
 
     /**
+     * Override current date.
+     *
+     * This allows validation at a particular point in time.
+     *
+     * @param \DateTimeInterface|string $date Either object or ISO8601 date string
+     *
+     * @return self
+     */
+    public function withDate($date)
+    {
+        if (is_string($date)) {
+            try {
+                Assert::regex($date, '{^[0-9]{4}-[0-9]{2}-[0-9]{2}$}', 'Expecting valid ISO8601 date (YYYY-MM-DD). Got: %s');
+            } catch (\InvalidArgumentException $e) {
+                throw E::wrap($e);
+            }
+
+            $now = \DateTime::createFromFormat('!Y-m-d', $date, $this->tz);
+
+            if (!$now instanceof \DateTime || $now->format('Y-m-d') !== $date) {
+                throw new InvalidArgumentException(sprintf(
+                    'Expecting valid ISO8601 date (YYYY-MM-DD). Got: "%s"',
+                    $date
+                ));
+            }
+        } else {
+            // @todo Remove this compatability check, didn't want to force upgrade of assert library.
+            if (method_exists('Webmozart\\Assert\\Assert', 'isInstanceOfAny')) {
+                try {
+                    Assert::isInstanceOfAny($date, [
+                        'DateTimeInterface',
+                        'DateTime',
+                        'DateTimeImmutable',
+                    ]);
+                } catch (\InvalidArgumentException $e) {
+                    throw E::wrap($e);
+                }
+            // Only need to check two here as \DateTimeImmutable is an instance of DateTimeInterface.
+            } elseif (!$date instanceof \DateTime && !$date instanceof \DateTimeInterface) {
+                throw new InvalidArgumentException('Expected an instance of any of "DateTimeInterface", "DateTime", "DateTimeImmutable".');
+            }
+
+            // Internally this library has to support PHP 5.4 so ensure using DateTime
+            // this also has the benefit of removing any time component which is not
+            // required.
+            $now = \DateTime::createFromFormat('!Y-m-d', $date->format('Y-m-d'), $date->getTimezone());
+            assert($now instanceof \DateTime && $now->format('Y-m-d') === $date->format('Y-m-d'));
+            $now->setTimezone($this->tz);
+        }
+
+        $factory = new self();
+        $factory->now = $now;
+        $factory->updateNow = false;
+
+        return $factory;
+    }
+
+    /**
      * @internal Used for testing
+     *
+     * @deprecated Replaced by withDate()
      *
      * @param \DateTime $now
      *
@@ -34,16 +98,14 @@ final class DefaultSpecFactory implements SpecFactoryInterface
      */
     public static function withNow(\DateTime $now)
     {
-        // Uses an error so error suppression ignores it.
-        trigger_error(sprintf('%s() is for testing only!', __METHOD__), E_USER_WARNING);
+        @trigger_error(sprintf(
+            '%s() is deprecated use withDate() instead. Note this method was marked @internal maybe removed in a minor release.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
 
-        $spec = new self();
-        $spec->now = clone $now;
-        $spec->now->setTime(0, 0, 0);
-        $spec->now->setTimezone($spec->tz);
-        $spec->updateNow = false;
+        $factory = new self();
 
-        return $spec;
+        return $factory->withDate($now);
     }
 
     /** {@inheritdoc} */

--- a/tests/Exception/UtilTest.php
+++ b/tests/Exception/UtilTest.php
@@ -57,5 +57,15 @@ final class UtilTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($e2, $e->getPrevious());
         $this->assertSame($e2->getMessage(), $e->getMessage());
         $this->assertSame($e2->getCode(), $e->getCode());
+
+        return $e;
+    }
+
+    /**
+     * @depends testWrap
+     */
+    public function testDoubleWrap(InvalidArgumentException $input)
+    {
+        $this->assertSame($input, Util::wrap($input));
     }
 }

--- a/tests/Spec/DefaultSpecFactoryTest.php
+++ b/tests/Spec/DefaultSpecFactoryTest.php
@@ -116,7 +116,7 @@ final class DefaultSpecFactoryTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Cs278\BankModulus\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Expected an instance of any of "DateTimeInterface", "DateTime", "DateTimeImmutable".
+     * @expectedExceptionMessage Expected an instance of DateTimeInterface. Got: stdClass
      */
     public function testWithDateObjectInvalid()
     {

--- a/tests/Spec/DefaultSpecFactoryTest.php
+++ b/tests/Spec/DefaultSpecFactoryTest.php
@@ -117,9 +117,24 @@ final class DefaultSpecFactoryTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \Cs278\BankModulus\Exception\InvalidArgumentException
      * @expectedExceptionMessage Expected an instance of DateTimeInterface. Got: stdClass
+     * @requires PHP 5.5
      */
     public function testWithDateObjectInvalid()
     {
+        $factory = new DefaultSpecFactory();
+        $factory->withDate(new \stdClass());
+    }
+
+    /**
+     * @expectedException \Cs278\BankModulus\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Expected an instance of DateTime. Got: stdClass
+     */
+    public function testWithDateObjectInvalidPhp54()
+    {
+        if (PHP_VERSION_ID >= 50500) {
+            $this->markTestSkipped('Test requires PHP < 5.5');
+        }
+
         $factory = new DefaultSpecFactory();
         $factory->withDate(new \stdClass());
     }

--- a/tests/Spec/DefaultSpecFactoryTest.php
+++ b/tests/Spec/DefaultSpecFactoryTest.php
@@ -20,7 +20,7 @@ final class DefaultSpecFactoryTest extends \PHPUnit_Framework_TestCase
      * @dataProvider dataCreateAtDate
      * @requires function error_clear_last
      */
-    public function testCreateAtDate($expectedSpec, \DateTime $now)
+    public function testCreateAtDateDeprecated($expectedSpec, \DateTime $now)
     {
         error_clear_last();
 
@@ -28,11 +28,28 @@ final class DefaultSpecFactoryTest extends \PHPUnit_Framework_TestCase
         $error = error_get_last();
 
         $this->assertArraySubset([
-            'message' => 'Cs278\\BankModulus\\Spec\\DefaultSpecFactory::withNow() is for testing only!',
-            'type' => E_USER_WARNING,
+            'message' => 'Cs278\\BankModulus\\Spec\\DefaultSpecFactory::withNow() is deprecated use withDate() instead. Note this method was marked @internal maybe removed in a minor release.',
+            'type' => E_USER_DEPRECATED,
         ], $error);
 
         error_clear_last();
+
+        // Run tests 5 times to ensure consistent results.
+        for ($i = 0; $i < 5; ++$i) {
+            $spec = $factory->create();
+
+            $this->assertInstanceOf('Cs278\\BankModulus\\Spec\\SpecInterface', $spec);
+            $this->assertInstanceOf('Cs278\\BankModulus\\Spec\\'.$expectedSpec, $spec);
+        }
+    }
+
+    /**
+     * @dataProvider dataCreateAtDate
+     */
+    public function testCreateAtDate($expectedSpec, \DateTime $now)
+    {
+        $factory = new DefaultSpecFactory();
+        $factory = $factory->withDate($now);
 
         // Run tests 5 times to ensure consistent results.
         for ($i = 0; $i < 5; ++$i) {
@@ -73,6 +90,70 @@ final class DefaultSpecFactoryTest extends \PHPUnit_Framework_TestCase
             ['VocaLinkV500', new \DateTime('2018-09-16')],
             ['VocaLinkV510', new \DateTime('2018-09-17')],
             ['VocaLinkV510', new \DateTime('2030-01-01')],
+        ];
+    }
+
+    public function testWithDateDateTime()
+    {
+        $factory = new DefaultSpecFactory();
+        $newFactory = $factory->withDate(new \DateTime('2018-01-01'));
+
+        $this->assertNotSame($factory, $newFactory);
+        $this->assertInstanceOf('Cs278\\BankModulus\\Spec\\VocaLinkV460', $newFactory->create());
+    }
+
+    /**
+     * @requires PHP 5.5.0
+     */
+    public function testWithDateDateTimeImmutable()
+    {
+        $factory = new DefaultSpecFactory();
+        $newFactory = $factory->withDate(new \DateTimeImmutable('2018-01-01'));
+
+        $this->assertNotSame($factory, $newFactory);
+        $this->assertInstanceOf('Cs278\\BankModulus\\Spec\\VocaLinkV460', $newFactory->create());
+    }
+
+    /**
+     * @expectedException \Cs278\BankModulus\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Expected an instance of any of "DateTimeInterface", "DateTime", "DateTimeImmutable".
+     */
+    public function testWithDateObjectInvalid()
+    {
+        $factory = new DefaultSpecFactory();
+        $factory->withDate(new \stdClass());
+    }
+
+    public function testWithDateString()
+    {
+        $factory = new DefaultSpecFactory();
+        $newFactory = $factory->withDate('2018-01-01');
+
+        $this->assertNotSame($factory, $newFactory);
+        $this->assertInstanceOf('Cs278\\BankModulus\\Spec\\VocaLinkV460', $newFactory->create());
+    }
+
+    /**
+     * @dataProvider dataWithDateStringInvalid
+     * @expectedException \Cs278\BankModulus\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Expecting valid ISO8601 date (YYYY-MM-DD). Got:
+     */
+    public function testWithDateStringInvalid($input)
+    {
+        $factory = new DefaultSpecFactory();
+        $factory->withDate($input);
+    }
+
+    public function dataWithDateStringInvalid()
+    {
+        return [
+            [''],
+            [' 2018-01-01'],
+            ['2018-01-01 '],
+            [' 2018-01-01 '],
+            ['18-01-01'],
+            ['ab18-01-01'],
+            ['2018-02-30'],
         ];
     }
 }


### PR DESCRIPTION
Fixes #21 

#### Usage

```php
$factory = new DefaultSpecFactory();

$factory = $factory->withDate('2018-01-31');
$factory = $factory->withDate(new \DateTime('2 weeks ago'));
$factory = $factory->withDate(new \DateTimeImmutable('next tuesday'));
```
