### PR TITLE
Drop HHVM testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ matrix:
     - php: 5.5
     - php: 5.6
       env: COVERAGE=yes
-    - php: hhvm
     - php: nightly
     - php: 7.0
     - php: 7.1
@@ -26,12 +25,11 @@ matrix:
     - php: 7.2
       env: PHPSTAN=yes
   allow_failures:
-    - php: hhvm
     - php: nightly
   fast_finish: true
 
 before_install:
-  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ] && [ "$TRAVIS_PHP_VERSION" != "nightly" ] && [ "$COVERAGE" != "yes" ]; then phpenv config-rm xdebug.ini; fi;
+  - if [ "$TRAVIS_PHP_VERSION" != "nightly" ] && [ "$COVERAGE" != "yes" ]; then phpenv config-rm xdebug.ini; fi;
   - composer self-update
   - echo 'zend.assertions=1' > $HOME/.phpenv/versions/$(phpenv version-name)/etc/conf.d/assert.ini
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   not impact consumers of this library. Use instance method
   `DefaultSpecFactory::withDate()` instead.
 
+### Removed
+- No longer testing on HHVM as PHP language support being dropped.
+
 ## [v1.7.0] - 2018-07-04
 
 ### Added


### PR DESCRIPTION
https://hhvm.com/blog/2018/09/12/end-of-php-support-future-of-hack.html